### PR TITLE
Add !findmacro command, pythonsimo CI tests, fix dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir -p pythonsimo-data && touch pythonsimo-data/placeholder
 
       - name: Build images
-        run: docker compose build ircdjs sandbox simojs
+        run: docker compose build ircdjs sandbox simojs pythonsimo
 
   integration-tests:
     name: IRC integration tests
@@ -60,7 +60,7 @@ jobs:
           mkdir -p pythonsimo-data && touch pythonsimo-data/placeholder
 
       - name: Start services
-        run: docker compose up --build -d ircdjs sandbox simojs
+        run: docker compose up --build -d ircdjs sandbox simojs pythonsimo
 
       - name: Wait for bot to connect
         run: |
@@ -75,7 +75,7 @@ jobs:
 
       - name: Show service logs on failure
         if: failure()
-        run: docker compose logs simojs sandbox ircdjs
+        run: docker compose logs simojs sandbox ircdjs pythonsimo
 
       - name: Stop services
         if: always()

--- a/features/sandcastle.js
+++ b/features/sandcastle.js
@@ -111,6 +111,14 @@ const printMacro = (client, channel, from, line) =>
 const listMacros = (client, channel, from, line) =>
     client.say(channel, Object.keys(macros).join(' '));
 
+const findMacro = (client, channel, from, line) => {
+    const terms = line.split(' ').slice(1);
+    const matches = Object.keys(macros).filter(name =>
+        terms.every(word => name.match(new RegExp(word, 'i')))
+    );
+    client.say(channel, matches.join(', '));
+};
+
 module.exports = {
     name: 'eval in a sandbox',
     commands: {
@@ -118,7 +126,8 @@ module.exports = {
         '!addmacro': newMacro,
         '!delmacro': delMacro,
         '!printmacro': printMacro,
-        '!listmacros': listMacros
+        '!listmacros': listMacros,
+        '!findmacro': findMacro
     },
     init: init
 }

--- a/main.js
+++ b/main.js
@@ -126,7 +126,3 @@ client.connect(function() {
    new TimerPoller(client, 30);
 });
 
-// Start twitter stream on connect
-setTimeout(
-    () => commands['!twitter'][0](client, config.channels[0], "startup", ""),
-    3000);

--- a/test/cases.json
+++ b/test/cases.json
@@ -3,17 +3,26 @@
   { "cmd": "!run exit(moment().format('YYYY'))",        "expect": "20\\d\\d", "desc": "moment global in sandbox" },
 
   { "cmd": "!addmacro +citest exit(arg * 2)",           "expect": "added macro", "desc": "add + macro (takes arg)" },
-  { "cmd": "!run +citest 21",                           "expect": "^42$",     "desc": "+ macro uses arg" },
+  { "cmd": "!+citest 21",                               "expect": "^42$",     "desc": "+ macro uses arg" },
 
   { "cmd": "!addmacro _ciprinter exit(21)",             "expect": "added macro", "desc": "add _ macro (prints)" },
-  { "cmd": "!run _ciprinter",                           "expect": "^21$",     "desc": "_ macro prints" },
+  { "cmd": "!_ciprinter",                               "expect": "^21$",     "desc": "_ macro prints" },
 
   { "cmd": "!addmacro *cichain +citest _ciprinter",     "expect": "added macro", "desc": "add * hypermacro" },
   { "cmd": "!*cichain",                                 "expect": "^42$",     "desc": "* chains _ output as + arg" },
+
+  { "cmd": "!findmacro citest",                         "expect": "\\+citest", "desc": "findmacro returns matching macro" },
 
   { "cmd": "!delmacro +citest",                         "expect": "removed",  "desc": "cleanup + macro" },
   { "cmd": "!delmacro _ciprinter",                      "expect": "removed",  "desc": "cleanup _ macro" },
   { "cmd": "!delmacro *cichain",                        "expect": "removed",  "desc": "cleanup * macro" },
 
-  { "cmd": "!cpu",                                      "expect": "memory",   "desc": "built-in feature" }
+  { "cmd": "!cpu",                                      "expect": "memory",   "desc": "built-in feature" },
+
+  { "cmd": "!c 5*5",                                   "expect": "^25$",     "desc": "pythonsimo calculator" },
+  { "cmd": "!r hello",                                  "expect": "^olleh$",  "desc": "pythonsimo string reverse" },
+
+  { "cmd": "!add ciexpl this is a ci expl",             "expect": "ciexpl",   "desc": "pythonsimo expl add" },
+  { "cmd": "!expl ciexpl",                              "expect": "ci expl",  "desc": "pythonsimo expl lookup" },
+  { "cmd": "!remove ciexpl 1",                          "expect": "Deleted",  "desc": "pythonsimo expl remove" }
 ]


### PR DESCRIPTION
- Add !findmacro as a proper built-in command replacing the old +findmacro macro that called the now-removed /list-macros endpoint
- Remove dead !twitter startup call in main.js that was crashing the bot on every start
- Add pythonsimo integration tests: !c (calculator), !r (reverse), and !add/!expl/!remove (expl redis round-trip)
- Fix CI test cases that called macros via !run +macro convention, use !+macro instead